### PR TITLE
Fix: Correctly apply CSS variable colors to snake game canvas

### DIFF
--- a/echoframe/templates/snake_quest.html
+++ b/echoframe/templates/snake_quest.html
@@ -664,14 +664,19 @@ function drawGameState(state) {
   // Clear and resize canvas
   clearCanvas();
   resizeCanvas(state.grid_width, state.grid_height);
+  // Get computed styles
+  const rootStyles = getComputedStyle(document.documentElement);
+
   // Draw snake
-  ctx.fillStyle = 'var(--preview-snake-color)';
+  const snakeColor = rootStyles.getPropertyValue('--preview-snake-color').trim();
+  ctx.fillStyle = snakeColor;
   (state.snake || []).forEach(([x, y]) => {
     ctx.fillRect(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE);
   });
   // Draw food
   if (state.food) {
-    ctx.fillStyle = 'var(--preview-food-color)';
+    const foodColor = rootStyles.getPropertyValue('--preview-food-color').trim();
+    ctx.fillStyle = foodColor;
     ctx.fillRect(state.food[0] * CELL_SIZE, state.food[1] * CELL_SIZE, CELL_SIZE, CELL_SIZE);
   }
   // Draw score


### PR DESCRIPTION
The canvas in the snake game preview remained blank because the `drawGameState` JavaScript function was attempting to use CSS custom properties (variables) directly for `ctx.fillStyle`. The Canvas API does not support this.

This commit modifies `snake_quest.html` so that the `drawGameState` function now retrieves the computed string values of the CSS custom properties (`--preview-snake-color` and `--preview-food-color`) using `getComputedStyle().getPropertyValue()`. These retrieved color strings are then correctly applied to `ctx.fillStyle`, enabling the snake and food to be rendered on the canvas as intended.